### PR TITLE
Add Stripe checkout session flow

### DIFF
--- a/Domain/PaymentGateway.php
+++ b/Domain/PaymentGateway.php
@@ -558,6 +558,42 @@ class StripeGateway implements IPaymentGateway
 
     /**
      * @param CreditCartSession $cart
+     * @param string $successUrl
+     * @param string $cancelUrl
+     * @param string $email
+     * @return \Stripe\Checkout\Session|null
+     */
+    public function CreateCheckoutSession(CreditCartSession $cart, string $successUrl, string $cancelUrl, string $email)
+    {
+        try {
+            \Stripe\Stripe::setApiKey($this->SecretKey());
+
+            $session = \Stripe\Checkout\Session::create([
+                'payment_method_types' => ['card'],
+                'customer_email' => $email,
+                'line_items' => [[
+                    'price_data' => [
+                        'currency' => strtolower($cart->Currency),
+                        'product_data' => ['name' => Resources::GetInstance()->GetString('Credits')],
+                        'unit_amount' => (new \Booked\Currency($cart->Currency))->ToStripe($cart->CostPerCredit()),
+                    ],
+                    'quantity' => $cart->Quantity,
+                ]],
+                'mode' => 'payment',
+                'success_url' => $successUrl . '&session_id={CHECKOUT_SESSION_ID}',
+                'cancel_url'  => $cancelUrl,
+            ]);
+
+            return $session;
+        } catch (Exception $ex) {
+            Log::Error('Stripe - error creating checkout session. %s', $ex);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param CreditCartSession $cart
      * @param string $email
      * @param string $token
      * @param IPaymentTransactionLogger $logger
@@ -627,6 +663,47 @@ class StripeGateway implements IPaymentGateway
             Log::Error('Stripe - error. %s', $ex);
         } catch (Exception $ex) {
             Log::Error('Stripe - internal error. %s', $ex);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $sessionId
+     * @param IPaymentTransactionLogger $logger
+     * @return bool
+     */
+    public function CompleteCheckoutSession(string $sessionId, IPaymentTransactionLogger $logger)
+    {
+        try {
+            \Stripe\Stripe::setApiKey($this->SecretKey());
+
+            $session = \Stripe\Checkout\Session::retrieve($sessionId, ['expand' => ['payment_intent']]);
+            $intent = $session->payment_intent;
+
+            if ($intent) {
+                $currency = new \Booked\Currency(strtoupper($intent->currency));
+                $chargeId = count($intent->charges->data) > 0 ? $intent->charges->data[0]->id : null;
+                $logger->LogPayment(
+                    ServiceLocator::GetServer()->GetUserSession()->UserId,
+                    $intent->status,
+                    $chargeId,
+                    $intent->id,
+                    $currency->FromStripe($intent->amount_received),
+                    0,
+                    strtoupper($intent->currency),
+                    null,
+                    null,
+                    Date::Now(),
+                    $intent->created,
+                    $this->GetGatewayType(),
+                    json_encode($session)
+                );
+
+                return $intent->status == 'succeeded';
+            }
+        } catch (Exception $ex) {
+            Log::Error('Stripe - complete checkout session error. %s', $ex);
         }
 
         return false;

--- a/Pages/Credits/CheckoutPage.php
+++ b/Pages/Credits/CheckoutPage.php
@@ -54,6 +54,10 @@ interface ICheckoutPage extends IActionPage
      */
     public function GetStripeToken();
 
+    public function GetStripeSessionId();
+
+    public function SetStripeSessionId($sessionId);
+
     /**
      * @param bool $result
      */
@@ -150,6 +154,16 @@ class CheckoutPage extends ActionPage implements ICheckoutPage
     public function GetStripeToken()
     {
         return $this->GetForm(FormKeys::STRIPE_TOKEN);
+    }
+
+    public function GetStripeSessionId()
+    {
+        return $this->GetQuerystring('session_id');
+    }
+
+    public function SetStripeSessionId($sessionId)
+    {
+        $this->SetJson(['id' => $sessionId]);
     }
 
     public function SetStripeResult($result)

--- a/Presenters/Credits/CheckoutPresenter.php
+++ b/Presenters/Credits/CheckoutPresenter.php
@@ -39,6 +39,7 @@ class CheckoutPresenter extends ActionPresenter
 
         $this->AddAction('executePayPalPayment', 'ExecutePayPalPayment');
         $this->AddAction('createPayPalPayment', 'CreatePayPalPayment');
+        $this->AddAction('createStripeSession', 'CreateStripeSession');
         $this->AddAction('executeStripePayment', 'ExecuteStripePayment');
     }
 
@@ -89,6 +90,24 @@ class CheckoutPresenter extends ActionPresenter
         $this->page->SetPayPalPayment($payment);
     }
 
+    public function CreateStripeSession()
+    {
+        $gateway = $this->paymentRepository->GetStripeGateway();
+        $baseUrl = new Url(Configuration::Instance()->GetScriptUrl());
+        $successUrl = $baseUrl->Copy()->Add(Pages::CHECKOUT);
+        $cancelUrl = $baseUrl->Copy()->Add(Pages::CHECKOUT);
+
+        /** @var CreditCartSession $cart */
+        $cart = ServiceLocator::GetServer()->GetSession(SessionKeys::CREDIT_CART);
+        $session = $gateway->CreateCheckoutSession($cart, $successUrl->ToString(), $cancelUrl->ToString(), ServiceLocator::GetServer()->GetUserSession()->Email);
+
+        if ($session !== null) {
+            $this->page->SetStripeSessionId($session->id);
+        } else {
+            $this->page->SetStripeSessionId(null);
+        }
+    }
+
     public function ExecutePayPalPayment()
     {
         $gateway = $this->paymentRepository->GetPayPalGateway();
@@ -109,17 +128,16 @@ class CheckoutPresenter extends ActionPresenter
 
     public function ExecuteStripePayment()
     {
-        $token = $this->page->GetStripeToken();
-        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        $sessionId = $this->page->GetStripeSessionId();
 
         $gateway = $this->paymentRepository->GetStripeGateway();
 
         /** @var CreditCartSession $cart  */
         $cart = ServiceLocator::GetServer()->GetSession(SessionKeys::CREDIT_CART);
-        $result = $gateway->Charge($cart, $userSession->Email, $token, $this->paymentLogger);
+        $result = $gateway->CompleteCheckoutSession($sessionId, $this->paymentLogger);
 
         if ($result == true) {
-            $user = $this->userRepository->LoadById($userSession->UserId);
+            $user = $this->userRepository->LoadById(ServiceLocator::GetServer()->GetUserSession()->UserId);
             $user->AddCredits($cart->Quantity, Resources::GetInstance()->GetString('NoteCreditsPurchased'));
             $this->userRepository->Update($user);
             ServiceLocator::GetServer()->SetSession(SessionKeys::CREDIT_CART, null);

--- a/tests/Presenters/CheckoutPresenterTest.php
+++ b/tests/Presenters/CheckoutPresenterTest.php
@@ -77,6 +77,25 @@ class CheckoutPresenterTest extends TestBase
         $this->assertEquals('/checkout.php?paypalaction=cancel', $gateway->_CancelUrl);
     }
 
+    public function testCreatesStripeSession()
+    {
+        $creditCartSession = new CreditCartSession(5, 10, 'USD', $this->fakeUser->UserId);
+        $this->fakeServer->SetSession(SessionKeys::CREDIT_CART, $creditCartSession);
+
+        $gateway = new FakeStripeGateway();
+        $session = new stdClass();
+        $session->id = 'sess_123';
+        $gateway->_Session = $session;
+        $this->paymentRepository->_Stripe = $gateway;
+
+        $this->presenter->CreateStripeSession();
+
+        $this->assertEquals($creditCartSession, $gateway->_CreateSessionCart);
+        $this->assertEquals('/checkout.php', $gateway->_CancelUrl);
+        $this->assertEquals('/checkout.php', strtok($gateway->_SuccessUrl, '?'));  // base url check
+        $this->assertEquals($session->id, $this->page->_StripeSessionId);
+    }
+
     public function testExecutesPayPalPayment()
     {
         $creditCartSession = new CreditCartSession(5, 10, 'USD', $this->fakeUser->UserId);
@@ -111,16 +130,15 @@ class CheckoutPresenterTest extends TestBase
 
         $this->userRepository->_User->WithCredits(10);
 
-        $this->page->_StripeToken = '123';
+        $this->page->_StripeSessionId = 'sess_123';
         $gateway = new FakeStripeGateway();
         $this->paymentRepository->_Stripe = $gateway;
-        $gateway->_ChargeResponse = true;
+        $gateway->_CompleteResult = true;
 
         $this->presenter->ExecuteStripePayment();
 
         $this->assertEquals(true, $this->page->_StripePaymentResult);
-        $this->assertEquals('123', $gateway->_Token);
-        $this->assertEquals($this->fakeUser->Email, $gateway->_Email);
+        $this->assertEquals('sess_123', $gateway->_CompleteSessionId);
         $this->assertNull($this->fakeServer->GetSession(SessionKeys::CREDIT_CART));
         $this->assertEquals(15, $this->userRepository->_UpdatedUser->GetCurrentCredits());
     }
@@ -143,6 +161,7 @@ class FakeCheckoutPage extends CheckoutPage
     public $_PayerId;
     public $_StripeToken;
     public $_StripePaymentResult;
+    public $_StripeSessionId;
 
     public function GetCreditCount()
     {
@@ -192,6 +211,16 @@ class FakeCheckoutPage extends CheckoutPage
     public function GetStripeToken()
     {
         return $this->_StripeToken;
+    }
+
+    public function GetStripeSessionId()
+    {
+        return $this->_StripeSessionId;
+    }
+
+    public function SetStripeSessionId($sessionId)
+    {
+        $this->_StripeSessionId = $sessionId;
     }
 
     public function SetStripeResult($result)

--- a/tests/fakes/FakeStripeGateway.php
+++ b/tests/fakes/FakeStripeGateway.php
@@ -9,10 +9,34 @@ class FakeStripeGateway extends StripeGateway
     public $_Cart;
     public $_Email;
     public $_ChargeResponse = false;
+    public $_CreateSessionCart;
+    public $_SuccessUrl;
+    public $_CancelUrl;
+    public $_SessionEmail;
+    public $_Session;
+    public $_CompleteSessionId;
+    public $_CompleteResult = false;
 
     public function __construct()
     {
         parent::__construct(true, '', '');
+    }
+
+    public function CreateCheckoutSession(CreditCartSession $cart, string $successUrl, string $cancelUrl, string $email)
+    {
+        $this->_CreateSessionCart = $cart;
+        $this->_SuccessUrl = $successUrl;
+        $this->_CancelUrl = $cancelUrl;
+        $this->_SessionEmail = $email;
+
+        return $this->_Session ?? (object)['id' => 'sess_test'];
+    }
+
+    public function CompleteCheckoutSession(string $sessionId, IPaymentTransactionLogger $logger)
+    {
+        $this->_CompleteSessionId = $sessionId;
+        $logger->LogPayment('', '', '', '', 0, 0, '', '', '', Date::Now(), '', '', '');
+        return $this->_CompleteResult;
     }
 
     public function Charge(CreditCartSession $cart, $email, $token, IPaymentTransactionLogger $logger)

--- a/tpl/Credits/checkout.tpl
+++ b/tpl/Credits/checkout.tpl
@@ -9,7 +9,7 @@
 			<script
 				src="https://www.paypal.com/sdk/js?client-id={$PayPalClientId}&intent=capture&currency={$Currency}&commit=true&disable-funding=credit">
 			</script>
-			<script src="https://checkout.stripe.com/checkout.js"></script>
+                        <script src="https://js.stripe.com/v3/"></script>
 
 			<div id="checkoutPage">
 
@@ -154,48 +154,45 @@
 
 						{/if}
 
-						{if $StripeEnabled}
+                                                {if $StripeEnabled}
 
-							var executeStripePaymentUrl = '{$smarty.server.SCRIPT_NAME}?action=executeStripePayment';
-							var handler = StripeCheckout.configure({
-								key: '{$StripePublishableKey}',
-								image: 'https://stripe.com/img/documentation/checkout/marketplace.png',
-								zipCode: true,
-								locale: 'auto',
-								currency: '{$Currency}',
-								email: '{$Email}',
-								token: function(token) {
-									var data = {
-										CSRF_TOKEN: $('#csrf_token').val(),
-										STRIPE_TOKEN: token.id
-									};
+                                                        const stripe = Stripe('{$StripePublishableKey}');
+                                                        document.getElementById('stripe-button').addEventListener('click', function () {
+                                                                const fd = new FormData();
+                                                                fd.append('CSRF_TOKEN', $('#csrf_token').val());
+                                                                fetch('{$smarty.server.SCRIPT_NAME}?action=createStripeSession', {
+                                                                        method: 'POST',
+                                                                        body: fd,
+                                                                        credentials: 'include'
+                                                                })
+                                                                .then(res => res.json())
+                                                                .then(data => stripe.redirectToCheckout({ sessionId: data.id }));
+                                                        });
 
-									$.post(executeStripePaymentUrl, data, function(d) {
-										$('#cart').addClass('d-none');
+                                                        const sid = '{$StripeSessionId}';
+                                                        if (sid) {
+                                                                const fd = new FormData();
+                                                                fd.append('CSRF_TOKEN', $('#csrf_token').val());
+                                                                fd.append('session_id', sid);
+                                                                fetch('{$smarty.server.SCRIPT_NAME}?action=executeStripePayment', {
+                                                                        method: 'POST',
+                                                                        body: fd,
+                                                                        credentials: 'include'
+                                                                })
+                                                                .then(res => res.json())
+                                                                .then(function(d) {
+                                                                        $('#cart').addClass('d-none');
+                                                                        if (d.result != true) {
+                                                                                $('#error').removeClass('d-none');
+                                                                        } else {
+                                                                                $('#success').removeClass('d-none');
+                                                                        }
+                                                                });
+                                                        }
 
-										if (d.result != true) {
-											$('#error').removeClass('d-none');
-										} else {
-											$('#success').removeClass('d-none');
-										}
-									});
-								}
-							});
-
-							document.getElementById('stripe-button').addEventListener('click', function(e) {
-								handler.open({
-									name: '{translate key=BuyMoreCredits}', description: '{$Total}', amount: {$TotalUnformatted * 100}
-								});
-								e.preventDefault();
-							});
-
-							window.addEventListener('popstate', function() {
-								handler.close();
-							});
-
-						{/if}
-					});
-				</script>
+                                                {/if}
+                                        });
+                                </script>
 
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- implement Stripe Checkout session support
- log completed Stripe sessions and update credits
- wire up presenter actions for Stripe sessions
- expose stripe session id in page helpers
- update Stripe JS integration to use Checkout v3
- expand tests and fakes for Stripe Checkout

## Testing
- `vendor/bin/phpunit tests/Presenters/CheckoutPresenterTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6857fb999148832790326efb5e7a4adf