### PR TITLE
Fix OAuth2 state handling

### DIFF
--- a/Presenters/Authentication/ExternalAuthLoginPresenter.php
+++ b/Presenters/Authentication/ExternalAuthLoginPresenter.php
@@ -168,7 +168,9 @@ class ExternalAuthLoginPresenter
         $realm        = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REALM);
         $clientId     = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_CLIENT_ID);
         $clientSecret = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_CLIENT_SECRET);
-        $redirectUri = rtrim(Configuration::Instance()->GetScriptUrl(), 'Web/') . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REDIRECT_URI);
+        $scriptUrl = Configuration::Instance()->GetScriptUrl();
+        $scriptUrl = preg_replace('#/Web/?$#', '', $scriptUrl);
+        $redirectUri = $scriptUrl . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REDIRECT_URI);
 
         $tokenEndpoint = rtrim($keycloakUrl, '/') . '/realms/' . urlencode($realm) . '/protocol/openid-connect/token';
 
@@ -234,12 +236,21 @@ class ExternalAuthLoginPresenter
     private function ProcessOauth2SingleSignOn()
     {
         $code = $_GET['code'];
+        $state = $_GET['state'] ?? '';
+        $expectedState = ServiceLocator::GetServer()->GetSession(SessionKeys::OAUTH2_STATE);
+        if (empty($state) || $state !== $expectedState) {
+            $this->page->ShowError(['Invalid OAuth2 state parameter.']);
+            return;
+        }
+        ServiceLocator::GetServer()->SetSession(SessionKeys::OAUTH2_STATE, null);
 
         $oauth2UrlToken  = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_URL_TOKEN);
         $oauth2UrlUserinfo = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_URL_USERINFO);
         $clientId     = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_CLIENT_ID);
         $clientSecret = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_CLIENT_SECRET);
-        $redirectUri = rtrim(Configuration::Instance()->GetScriptUrl(), 'Web/') . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_REDIRECT_URI);
+        $scriptUrl = Configuration::Instance()->GetScriptUrl();
+        $scriptUrl = preg_replace('#/Web/?$#', '', $scriptUrl);
+        $redirectUri = $scriptUrl . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_REDIRECT_URI);
 
         // Prepare the POST data for the token request.
         $postData = [

--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -306,7 +306,9 @@ class LoginPresenter
             $baseUrl     = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_URL);
             $realm       = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REALM);
             $clientId    = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_CLIENT_ID);
-            $redirectUri = rtrim(Configuration::Instance()->GetScriptUrl(), 'Web/') . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REDIRECT_URI);
+            $scriptUrl = Configuration::Instance()->GetScriptUrl();
+            $scriptUrl = preg_replace('#/Web/?$#', '', $scriptUrl);
+            $redirectUri = $scriptUrl . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REDIRECT_URI);
 
             // Construct the Keycloak authentication URL
             $keycloakUrl = rtrim($baseUrl, '/')
@@ -327,14 +329,20 @@ class LoginPresenter
             // Retrieve Oauth2 configuration values
             $baseUrl     = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_URL_AUTHORIZE);
             $clientId    = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_CLIENT_ID);
-            $redirectUri = rtrim(Configuration::Instance()->GetScriptUrl(), 'Web/') . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_REDIRECT_URI);
+            $scriptUrl = Configuration::Instance()->GetScriptUrl();
+            $scriptUrl = preg_replace('#/Web/?$#', '', $scriptUrl);
+            $redirectUri = $scriptUrl . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::OAUTH2_REDIRECT_URI);
+
+            $state = bin2hex(random_bytes(16));
+            ServiceLocator::GetServer()->SetSession(SessionKeys::OAUTH2_STATE, $state);
 
             // Construct the Oauth2 authentication URL
             $Oauth2Url = $baseUrl
                 . '?client_id=' . urlencode($clientId)
                 . '&redirect_uri=' . urlencode($redirectUri)
                 . '&response_type=code'
-                . '&scope=' . urlencode('openid email profile');
+                . '&scope=' . urlencode('openid email profile')
+                . '&state=' . urlencode($state);
 
             return $Oauth2Url;
         }

--- a/Web/oauth2-auth.php
+++ b/Web/oauth2-auth.php
@@ -6,7 +6,12 @@ require_once(ROOT_DIR . 'lib/Common/namespace.php');
 //Checks if the user was authenticated by oauth2 and redirects to external authentication page
 if (isset($_GET['code'])) {
     $code = filter_input(INPUT_GET, 'code');
-    header("Location: " . ROOT_DIR . "Web/external-auth.php?type=oauth2&code=" . $code);
+    $state = filter_input(INPUT_GET, 'state');
+    $url = ROOT_DIR . "Web/external-auth.php?type=oauth2&code=" . $code;
+    if (!empty($state)) {
+        $url .= "&state=" . urlencode($state);
+    }
+    header("Location: " . $url);
     exit;
 } else {
     header("Location:" . ROOT_DIR . "Web");

--- a/lib/Server/SessionKeys.php
+++ b/lib/Server/SessionKeys.php
@@ -9,4 +9,5 @@ class SessionKeys
     public const CREDIT_CART = 'CREDIT_CART';
     public const USER_SESSION = 'USER_SESSION';
     public const INSTALLATION = 'INSTALLATION';
+    public const OAUTH2_STATE = 'OAUTH2_STATE';
 }


### PR DESCRIPTION
## Summary
- prevent overzealous trimming of Keycloak/OAuth2 redirect URL
- implement OAuth2 `state` parameter for CSRF protection

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ab56833a08327bde2f8e17adadf04