### PR TITLE
Add Credit Automation admin and job

### DIFF
--- a/Jobs/dailycredits.php
+++ b/Jobs/dailycredits.php
@@ -1,0 +1,45 @@
+<?php
+/**
+* Cron job to award daily credits and apply credit tax
+*/
+
+define('ROOT_DIR', __DIR__ . '/../');
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'lib/Database/Commands/namespace.php');
+require_once(ROOT_DIR . 'Jobs/JobCop.php');
+require_once(ROOT_DIR . 'lib/Config/Configuration.php');
+
+Log::Debug('Running dailycredits.php');
+JobCop::EnsureCommandLine();
+
+try {
+    $amount = floatval(Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_DAILY_AMOUNT));
+    $groupIds = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_DAILY_GROUPS);
+    $groups = array_filter(array_map('intval', explode(',', $groupIds)));
+    $taxPercent = floatval(Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_TAX_PERCENT));
+
+    $groupRepo = new GroupRepository();
+    $db = ServiceLocator::GetDatabase();
+    foreach ($groups as $gid) {
+        $group = $groupRepo->LoadById($gid);
+        foreach ($group->UserIds() as $uid) {
+            if ($amount > 0) {
+                $db->Execute(new AdjustUserCreditsCommand($uid, -$amount, Resources::GetInstance()->GetString('NoteDailyCreditsAwarded')));
+            }
+            if ($taxPercent > 0) {
+                $reader = $db->Query(new AdHocCommand('SELECT credit_count FROM users WHERE user_id = ' . intval($uid)));
+                $credit = 0;
+                if ($row = $reader->GetRow()) { $credit = $row[0]; }
+                $reader->Free();
+                $deduct = round($credit * $taxPercent / 100, 2);
+                if ($deduct > 0) {
+                    $db->Execute(new AdjustUserCreditsCommand($uid, $deduct, Resources::GetInstance()->GetString('NoteCreditTaxed')));
+                }
+            }
+        }
+    }
+} catch (Exception $ex) {
+    Log::Error('Error running dailycredits.php: %s', $ex);
+}
+
+Log::Debug('Finished running dailycredits.php');

--- a/Pages/Admin/ManageCreditAutomationPage.php
+++ b/Pages/Admin/ManageCreditAutomationPage.php
@@ -1,0 +1,72 @@
+<?php
+
+require_once(ROOT_DIR . 'Pages/Admin/AdminPage.php');
+require_once(ROOT_DIR . 'Presenters/Admin/ManageCreditAutomationPresenter.php');
+require_once(ROOT_DIR . 'Domain/Access/GroupRepository.php');
+require_once(ROOT_DIR . 'lib/Config/Configuration.php');
+
+interface IManageCreditAutomationPage extends IActionPage
+{
+    public function GetDailyAmount();
+    public function GetDailyTime();
+    public function GetTaxPercent();
+    public function GetGroups();
+    public function BindGroups($groups, $selected);
+    public function BindSettings($amount, $time, $tax);
+}
+
+class ManageCreditAutomationPage extends ActionPage implements IManageCreditAutomationPage
+{
+    private $presenter;
+
+    public function __construct()
+    {
+        parent::__construct('ManageCreditAutomation', 1);
+        $this->presenter = new ManageCreditAutomationPresenter($this, new GroupRepository(), new Configurator());
+    }
+
+    public function ProcessPageLoad()
+    {
+        $this->presenter->PageLoad();
+        $this->Display('manage_credit_automation.tpl');
+    }
+    public function ProcessDataRequest($dataRequest){}
+
+    public function ProcessAction()
+    {
+        $this->presenter->ProcessAction();
+    }
+
+    public function GetDailyAmount()
+    {
+        return $this->GetForm('dailyAmount');
+    }
+
+    public function GetDailyTime()
+    {
+        return $this->GetForm('dailyTime');
+    }
+
+    public function GetTaxPercent()
+    {
+        return $this->GetForm('taxPercent');
+    }
+
+    public function GetGroups()
+    {
+        return $this->GetForm('groups');
+    }
+
+    public function BindGroups($groups, $selected)
+    {
+        $this->Set('Groups', $groups);
+        $this->Set('SelectedGroups', $selected);
+    }
+
+    public function BindSettings($amount, $time, $tax)
+    {
+        $this->Set('DailyAmount', $amount);
+        $this->Set('DailyTime', $time);
+        $this->Set('TaxPercent', $tax);
+    }
+}

--- a/Presenters/Admin/ManageCreditAutomationPresenter.php
+++ b/Presenters/Admin/ManageCreditAutomationPresenter.php
@@ -1,0 +1,49 @@
+<?php
+require_once(ROOT_DIR . 'Presenters/ActionPresenter.php');
+require_once(ROOT_DIR . 'Pages/Admin/ManageCreditAutomationPage.php');
+require_once(ROOT_DIR . 'lib/Config/Configurator.php');
+
+class ManageCreditAutomationActions
+{
+    public const SAVE = 'save';
+}
+
+class ManageCreditAutomationPresenter extends ActionPresenter
+{
+    private $page;
+    private $groups;
+    private $config;
+    private $configFile;
+
+    public function __construct(IManageCreditAutomationPage $page, IGroupRepository $groups, IConfigurationSettings $config)
+    {
+        parent::__construct($page);
+        $this->page = $page;
+        $this->groups = $groups;
+        $this->config = $config;
+        $this->configFile = ROOT_DIR . 'config/config.php';
+        $this->AddAction(ManageCreditAutomationActions::SAVE, 'Save');
+    }
+
+    public function PageLoad()
+    {
+        $groupList = $this->groups->GetList()->Results();
+        $selected = explode(',', Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_DAILY_GROUPS));
+        $this->page->BindGroups($groupList, $selected);
+
+        $amount = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_DAILY_AMOUNT);
+        $time = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_DAILY_TIME);
+        $tax = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_TAX_PERCENT);
+        $this->page->BindSettings($amount, $time, $tax);
+    }
+
+    public function Save()
+    {
+        $settings = $this->config->GetSettings($this->configFile);
+        $settings['credits'][ConfigKeys::CREDITS_DAILY_AMOUNT] = $this->page->GetDailyAmount();
+        $settings['credits'][ConfigKeys::CREDITS_DAILY_GROUPS] = implode(',', (array)$this->page->GetGroups());
+        $settings['credits'][ConfigKeys::CREDITS_DAILY_TIME] = $this->page->GetDailyTime();
+        $settings['credits'][ConfigKeys::CREDITS_TAX_PERCENT] = $this->page->GetTaxPercent();
+        $this->config->WriteSettings($this->configFile, $settings);
+    }
+}

--- a/Web/admin/manage_credit_automation.php
+++ b/Web/admin/manage_credit_automation.php
@@ -1,0 +1,5 @@
+<?php
+require_once('../AdminPage.php');
+require_once('../../Pages/Admin/ManageCreditAutomationPage.php');
+$page = new AdminPageDecorator(new ManageCreditAutomationPage());
+$page->PageLoad();

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -195,6 +195,10 @@ $conf['settings']['authentication']['captcha.on.login'] = 'false';
  */
 $conf['settings']['credits']['enabled'] = 'false';
 $conf['settings']['credits']['allow.purchase'] = 'false';
+$conf['settings']['credits']['daily.amount'] = '0';
+$conf['settings']['credits']['daily.groups'] = '';
+$conf['settings']['credits']['daily.time'] = '00:00';
+$conf['settings']['credits']['tax.percent'] = '0';
 /**
  * Slack integration
  */

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -199,6 +199,10 @@ $conf['settings']['authentication']['captcha.on.login'] = 'false';
  */
 $conf['settings']['credits']['enabled'] = 'false';
 $conf['settings']['credits']['allow.purchase'] = 'false';
+$conf['settings']['credits']['daily.amount'] = '0';
+$conf['settings']['credits']['daily.groups'] = '';
+$conf['settings']['credits']['daily.time'] = '00:00';
+$conf['settings']['credits']['tax.percent'] = '0';
 /**
  * Slack integration
  */

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -654,6 +654,8 @@ class ar extends en_us
         $strings['TryAgain'] = 'محاولة مرة اخرى ';
         $strings['PurchaseFailed'] = 'لقد واجهتنا مشكلة في معالجة دفعتك.';
         $strings['NoteCreditsPurchased'] = 'شراء الاعتمادات';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'تم تحديث الاعتمادات بواسطة %s';
         $strings['ReservationCreatedLog'] = 'تم إنشاء الحجز. رقم المرجع %s';
         $strings['ReservationUpdatedLog'] = 'تم تحديث الحجز. رقم المرجع %s';
@@ -935,6 +937,7 @@ class ar extends en_us
         $strings['ReservationColors'] = 'الوان الحجوزات ';
         $strings['SearchReservations'] = 'بحث عن الحجوزات';
         $strings['ManagePayments'] = 'المدفوعات';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'عرض التقويم';
         $strings['DataCleanup'] = 'تنظيف البيانات';
         $strings['ManageEmailTemplates'] = 'إدارة قوالب البريد الإلكتروني';

--- a/lang/da_da.php
+++ b/lang/da_da.php
@@ -649,6 +649,8 @@ class da_da extends en_gb
         $strings['TryAgain'] = 'Prøv igen';
         $strings['PurchaseFailed'] = 'Der var problemer med din betaling';
         $strings['NoteCreditsPurchased'] = 'Mønter anskaffet';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Mønter er opdateret med %s';
         $strings['ReservationCreatedLog'] = 'Din reservation er oprettet. Referencenummer %s';
         $strings['ReservationUpdatedLog'] = 'Din reservation er opdateret. Referencenummer %s';
@@ -930,6 +932,7 @@ class da_da extends en_gb
         $strings['ReservationColors'] = 'Reservationsfarver';
         $strings['SearchReservations'] = 'Find reservation';
         $strings['ManagePayments'] = 'Betalling';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Se kalender';
         $strings['DataCleanup'] = 'Fjern data';
         $strings['ManageEmailTemplates'] = 'E-mailskabeloner';

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -615,6 +615,8 @@ class de_de extends en_gb
         $strings['TryAgain'] = 'Noch einmal versuchen';
         $strings['PurchaseFailed'] = 'Wir konnten ihre Bezahlung nicht vollständig abwickeln.';
         $strings['NoteCreditsPurchased'] = 'Punkte gekauft';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Punkte aktualisiert durch %s';
         $strings['ReservationCreatedLog'] = 'Reservierung angelegt. Referenznummer %s';
         $strings['ReservationUpdatedLog'] = 'Reservierung aktualisiert. Referenznummer %s';
@@ -909,6 +911,7 @@ class de_de extends en_gb
         $strings['ReservationColors'] = 'Reservierungsfarben';
         $strings['SearchReservations'] = 'Reservierungen finden';
         $strings['ManagePayments'] = 'Zahlungen';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Kalender anschauen';
         $strings['DataCleanup'] = 'Daten aufräumen';
         $strings['ManageEmailTemplates'] = 'E-Mail Vorlagen bearbeiten';

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -624,6 +624,8 @@ class du_nl extends en_gb
         $strings['TryAgain'] = 'Probeer opnieuw';
         $strings['PurchaseFailed'] = 'We had trouble processing your payment.';
         $strings['NoteCreditsPurchased'] = 'Credits purchased';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Credits updated by %s';
         $strings['ReservationCreatedLog'] = 'Reservation created. Reference number %s';
         $strings['ReservationUpdatedLog'] = 'Reservation updated. Reference number %s';
@@ -922,6 +924,7 @@ class du_nl extends en_gb
         $strings['ReservationColors'] = 'Reserverings kleur';
 		$strings['SearchReservations'] = 'Zoek reservering';
 		$strings['ManagePayments'] = 'Betalingen';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
 		$strings['ViewCalendar'] = 'Bekijk kalender';
 		$strings['DataCleanup'] = 'Data opschonen';
 		$strings['ManageEmailTemplates'] = 'E-mail sjablonen beheren';

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -654,6 +654,8 @@ class el_gr extends en_gb
         $strings['TryAgain'] = 'Δοκιμάστε πάλι';
         $strings['PurchaseFailed'] = 'Πρόβλημα κατά την επεξεργασία της πληρωμής σας.';
         $strings['NoteCreditsPurchased'] = 'Τα credits αγοράστηκαν';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Τα credits τροποποιήθηκαν από %s';
         $strings['ReservationCreatedLog'] = 'Η κράτηση δημιουργήθηκε. Αριθμός αναφοράς %s';
         $strings['ReservationUpdatedLog'] = 'Η κράτηση τροποποιήθηκε. Αριθμός αναφοράς %s';
@@ -947,6 +949,7 @@ class el_gr extends en_gb
         $strings['ReservationColors'] = 'Χρώματα Κρατήσεων';
         $strings['SearchReservations'] = 'Αναζήτηση στις Κρατήσεις';
         $strings['ManagePayments'] = 'Πληρωμές';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Εμφάνιση Ημερολογίου';
         $strings['DataCleanup'] = 'Εκκαθάριση Δεδομένων';
         $strings['ManageEmailTemplates'] = 'Διαχείριση Προτύπων Email';

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -657,9 +657,13 @@ class en_us extends Language
         $strings['TryAgain'] = 'Try Again';
         $strings['PurchaseFailed'] = 'We had trouble processing your payment.';
         $strings['NoteCreditsPurchased'] = 'Credits purchased';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Credits updated by %s';
         $strings['ReservationCreatedLog'] = 'Reservation created. Reference number %s';
         $strings['ReservationUpdatedLog'] = 'Reservation updated. Reference number %s';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['ReservationDeletedLog'] = 'Reservation deleted. Reference number %s';
         $strings['BuyMoreCredits'] = 'Buy More Credits';
         $strings['Transactions'] = 'Transactions';
@@ -952,6 +956,8 @@ class en_us extends Language
         $strings['ReservationColors'] = 'Reservation Colors';
         $strings['SearchReservations'] = 'Search Reservations';
         $strings['ManagePayments'] = 'Payments';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'View Calendar';
         $strings['DataCleanup'] = 'Data Cleanup';
         $strings['ManageEmailTemplates'] = 'Manage Email Templates';

--- a/lang/es.php
+++ b/lang/es.php
@@ -620,6 +620,8 @@ class es extends en_gb
         $strings['TryAgain'] = 'Intentar de nuevo';
         $strings['PurchaseFailed'] = 'Hemos tenido problemas procesando su pago.';
         $strings['NoteCreditsPurchased'] = 'Créditos comprados';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Créditos actualizados por %s';
         $strings['ReservationCreatedLog'] = 'Reserva creada. Número de referencia %s';
         $strings['ReservationUpdatedLog'] = 'Reserva actualizada. Número de referencia %s';
@@ -915,6 +917,7 @@ class es extends en_gb
         $strings['ReservationColors'] = 'Colores de las reservas';
         $strings['SearchReservations'] = 'Buscar Reservas';
         $strings['ManagePayments'] = 'Pagos';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Ver Calendario';
         $strings['DataCleanup'] = 'Limpiar Datos';
         $strings['ManageEmailTemplates'] = 'Administrar Plantillas de Correo Electrónico';

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -627,6 +627,8 @@ class fi_fi extends en_gb
         $strings['TryAgain'] = 'Yritä Uudelleen';
         $strings['PurchaseFailed'] = 'Maksusi kanssa oli ongelmia.';
         $strings['NoteCreditsPurchased'] = 'Krediittiä ostettu';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = '%s on päivittänyt Krediitit';
         $strings['ReservationCreatedLog'] = 'Varaus luotu. Varausnumero %s';
         $strings['ReservationUpdatedLog'] = 'Varaus päivitetty. Varausnumero %s';
@@ -846,6 +848,7 @@ class fi_fi extends en_gb
         $strings['ReservationColors'] = 'Varausten Värit';
         $strings['SearchReservations'] = 'Etsi Varauksia';
         $strings['ManagePayments'] = 'Maksut';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Katso Kalenteria';
         $strings['DataCleanup'] = 'Datan Poista';
         $strings['ManageEmailTemplates'] = 'Hallitse Sähköpostipohjia';

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -619,6 +619,8 @@ class fr_fr extends en_gb
         $strings['TryAgain'] = 'Essayer à nouveau';
         $strings['PurchaseFailed'] = 'Nous avons eu un probème lors du traitement de votre paiement.';
         $strings['NoteCreditsPurchased'] = 'Crédits achetés';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Crédits achetés par %s';
         $strings['ReservationCreatedLog'] = 'Réservation créée. Numéro de reference %s';
         $strings['ReservationUpdatedLog'] = 'Réservation modifiée. Numéro de reference %s';
@@ -912,6 +914,7 @@ class fr_fr extends en_gb
         $strings['ReservationColors'] = 'Couleurs des Réservations';
         $strings['SearchReservations'] = 'Rechercher des Réservations';
         $strings['ManagePayments'] = 'Paiements';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Voir le Calendrier';
         $strings['DataCleanup'] = 'Nettoyage des données';
         $strings['ManageEmailTemplates'] = 'Gérer les Modèles de Email';

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -648,6 +648,8 @@ class hu_hu extends en_us
         $strings['TryAgain'] = 'Újra próbál';
         $strings['PurchaseFailed'] = 'Probléma a fizetés közben.';
         $strings['NoteCreditsPurchased'] = 'Egység megvásárolva';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Egység frissítve %s által';
         $strings['ReservationCreatedLog'] = 'Foglalás létrehozva. Referenciaszám %s';
         $strings['ReservationUpdatedLog'] = 'Foglalás frissítve. Referenciaszám %s';
@@ -908,6 +910,7 @@ class hu_hu extends en_us
         $strings['ReservationColors'] = 'Foglalások színei';
         $strings['SearchReservations'] = 'Foglalás keresése';
         $strings['ManagePayments'] = 'Kifizetések';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Naptár megtekintése';
         $strings['DataCleanup'] = 'Adat törlés';
         $strings['ManageEmailTemplates'] = 'E-mail sablonok kezelése';

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -652,6 +652,8 @@ class it_it extends en_us
         $strings['TryAgain'] = 'Riprova';
         $strings['PurchaseFailed'] = 'Abbiamo riscontrato problemi durante l&apos;elaborazione del pagamento.';
         $strings['NoteCreditsPurchased'] = 'Crediti acquistati';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Crediti aggiornati da %s';
         $strings['ReservationCreatedLog'] = 'Prenotazione creata. Numero Riferimento %s';
         $strings['ReservationUpdatedLog'] = 'Prenotazione aggiornata. Numero Riferimento %s';
@@ -948,6 +950,7 @@ class it_it extends en_us
         $strings['ReservationColors'] = 'Colori delle prenotazioni';
         $strings['SearchReservations'] = 'Cerca Prenotazioni';
         $strings['ManagePayments'] = 'Pagamenti';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Visualizza calendario';
         $strings['DataCleanup'] = 'Pulizia dei dati';
         $strings['ManageEmailTemplates'] = 'Gestisci template email';

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -660,6 +660,8 @@ class ja_jp extends en_gb
         $strings['TryAgain'] = '再試行';
         $strings['PurchaseFailed'] = '支払いの処理中に問題が発生しました';
         $strings['NoteCreditsPurchased'] = '購入したクレジット';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = '%s が更新したクレジット';
         $strings['ReservationCreatedLog'] = '予約が作成されました。参照番号 %s ';
         $strings['ReservationUpdatedLog'] = '予約が変更されました。参照番号 %s ';
@@ -927,6 +929,7 @@ class ja_jp extends en_gb
         $strings['SearchReservations'] = '予約の検索';
 
         $strings['ManagePayments'] = '支払';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'カレンダーを表示';
         $strings['DataCleanup'] = 'データクリーンアップ';
         $strings['ManageEmailTemplates'] = 'メールテンプレートの管理';

--- a/lang/lt.php
+++ b/lang/lt.php
@@ -619,6 +619,8 @@ class lt extends en_gb
         $strings['TryAgain'] = 'Try Again';
         $strings['PurchaseFailed'] = 'We had trouble processing your payment.';
         $strings['NoteCreditsPurchased'] = 'Credits purchased';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Credits updated by %s';
         $strings['ReservationCreatedLog'] = 'Reservation created. Reference number %s';
         $strings['ReservationUpdatedLog'] = 'Reservation updated. Reference number %s';
@@ -912,6 +914,7 @@ class lt extends en_gb
         $strings['ReservationColors'] = 'Rezervacijų spalvos';
         $strings['SearchReservations'] = 'Ieškoti rezervacijų';
         $strings['ManagePayments'] = 'Payments';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'View Calendar';
         $strings['DataCleanup'] = 'Data Cleanup';
         $strings['ManageEmailTemplates'] = 'Manage Email Templates';

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -658,6 +658,8 @@ class pl extends en_gb
         $strings['TryAgain'] = 'Spróbuj ponownie';
         $strings['PurchaseFailed'] = 'Wystąpił problem z przetwarzaniem Twojej płatności.';
         $strings['NoteCreditsPurchased'] = 'Zakupione żetony';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Żetony zaktualizowane przez %s';
         $strings['ReservationCreatedLog'] = 'Rezerwacja utworzona: Nr referencyjny: %s';
         $strings['ReservationUpdatedLog'] = 'Rezerwacja zmieniona: Nr referencyjny:%s';
@@ -953,6 +955,7 @@ class pl extends en_gb
         $strings['ReservationColors'] = 'Kolory rezerwacji';
         $strings['SearchReservations'] = 'Przeszukaj rezerwacje';
         $strings['ManagePayments'] = 'Płatności';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Podgląd kalendarza';
         $strings['DataCleanup'] = 'Czyszczenie danych';
         $strings['ManageEmailTemplates'] = 'Zarządzaj szablonami e-maili';

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -637,6 +637,8 @@ class pt_br extends en_gb
         $strings['TryAgain'] = 'Tente novamente';
         $strings['PurchaseFailed'] = 'Ocorreu um problema ao processar seu pagamento.';
         $strings['NoteCreditsPurchased'] = 'Créditos adquiridos';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Créditos atualizados por %s';
         $strings['ReservationCreatedLog'] = 'Reserva criada. Número de referência %s';
         $strings['ReservationUpdatedLog'] = 'Reserva atualizada. Número de referência %s';
@@ -936,6 +938,7 @@ class pt_br extends en_gb
         $strings['ReservationColors'] = 'Cores das reservas';
         $strings['SearchReservations'] = 'Pesquisar reservas';
         $strings['ManagePayments'] = 'Pagamentos';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Exibir calendário';
         $strings['DataCleanup'] = 'Limpeza de dados';
         $strings['ManageEmailTemplates'] = 'Gerenciar Modelos de E-mail';

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -459,6 +459,7 @@ class pt_pt extends en_gb
         $strings['ManageEmailTemplates'] = 'Gerir modelos de email';
         $strings['ManageGroups'] = 'Grupos';
         $strings['ManagePayments'] = 'Pagamentos';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ManageQuotas'] = 'Quotas';
         $strings['ManageReminders'] = 'Lembretes';
         $strings['ManageReservations'] = 'Reservas';
@@ -538,6 +539,8 @@ class pt_pt extends en_gb
         $strings['NotSignedIn'] = 'Não está logado';
         $strings['Note'] = 'Nota';
         $strings['NoteCreditsPurchased'] = 'Créditos adquiridos';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['Notes'] = 'Notas';
         $strings['NotificationPreferences'] = 'Preferências de Notificação';
         $strings['NotifyUser'] = 'Notificar utilizador';

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -9,6 +9,10 @@ class ConfigKeys
     public const ALLOW_REGISTRATION = 'allow.self.registration';
     public const CREDITS_ENABLED = 'enabled';
     public const CREDITS_ALLOW_PURCHASE = 'allow.purchase';
+    public const CREDITS_DAILY_AMOUNT = 'daily.amount';
+    public const CREDITS_DAILY_GROUPS = 'daily.groups';
+    public const CREDITS_DAILY_TIME = 'daily.time';
+    public const CREDITS_TAX_PERCENT = 'tax.percent';
     public const CSS_EXTENSION_FILE = 'css.extension.file';
     public const CSS_THEME = 'css.theme';
     public const DEFAULT_HOMEPAGE = 'default.homepage';

--- a/tests/Presenters/Admin/ManageCreditAutomationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageCreditAutomationPresenterTest.php
@@ -1,0 +1,63 @@
+<?php
+require_once(ROOT_DIR . 'Presenters/Admin/ManageCreditAutomationPresenter.php');
+
+class ManageCreditAutomationPresenterTest extends TestBase
+{
+    private $page;
+    private $presenter;
+    private $groupRepo;
+    private $config;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->page = new FakeCreditAutomationPage();
+        $this->groupRepo = new FakeGroupRepository();
+        $this->config = new FakeConfigurator();
+        $this->presenter = new ManageCreditAutomationPresenter($this->page, $this->groupRepo, $this->config);
+    }
+
+    public function testPageLoadBindsGroups()
+    {
+        $group = new Group(1, 'g');
+        $this->groupRepo->_groups = [new GroupItemView($group->Id(), $group->Name())];
+        $this->config->_settings = ['credits'=>[ConfigKeys::CREDITS_DAILY_GROUPS=>'1',ConfigKeys::CREDITS_DAILY_AMOUNT=>'5',ConfigKeys::CREDITS_DAILY_TIME=>'00:00',ConfigKeys::CREDITS_TAX_PERCENT=>'1']];
+        $this->presenter->PageLoad();
+        $this->assertEquals(1, count($this->page->_Groups));
+    }
+}
+
+class FakeCreditAutomationPage extends ManageCreditAutomationPage
+{
+    public $_Groups;
+    public $_Selected;
+    public $_Amount;
+    public $_Time;
+    public $_Tax;
+
+    public function __construct(){parent::__construct();}
+    public function BindGroups($groups, $selected){$this->_Groups=$groups;$this->_Selected=$selected;}
+    public function BindSettings($a,$t,$x){$this->_Amount=$a;$this->_Time=$t;$this->_Tax=$x;}
+}
+
+class FakeGroupRepository implements IGroupRepository
+{
+    public $_groups = [];
+    public function GetList($p=null,$s=null,$sf=null,$sd=null,$f=null){return new PageableData($this->_groups, count($this->_groups),1,1);}
+    public function LoadById($id){return new Group($id,'g');}
+    public function Add(Group $g){}
+    public function Update(Group $g){}
+    public function Remove(Group $g){}
+    public function GetUsersInGroup($ids,$pn=null,$ps=null,$f=null,$st=AccountStatus::ALL){}
+    public function GetGroupsByRole($r){}
+    public function GetPermissionList(){}
+}
+
+class FakeConfigurator implements IConfigurationSettings
+{
+    public $_settings=[];
+    public function GetSettings($file){return $this->_settings;}
+    public function BuildConfig($c,$n,$r=false){}
+    public function WriteSettings($path,$set){$this->_settings=$set;}
+    public function CanOverwriteFile($f){return true;}
+}

--- a/tpl/Admin/manage_credit_automation.tpl
+++ b/tpl/Admin/manage_credit_automation.tpl
@@ -1,0 +1,31 @@
+{include file='globalheader.tpl'}
+
+<div id="page-manage-credit-automation" class="admin-page">
+    <h1 class="border-bottom mb-3">{translate key=ManageCreditAutomation}</h1>
+    <form id="credit-automation-form" method="post" action="manage_credit_automation.php">
+        <div class="mb-3">
+            <label for="dailyAmount" class="form-label">{translate key="Credits"}</label>
+            <input type="number" step="0.01" class="form-control w-auto" name="dailyAmount" id="dailyAmount" value="{$DailyAmount}">
+        </div>
+        <div class="mb-3">
+            <label for="dailyTime" class="form-label">{translate key="Time"}</label>
+            <input type="time" class="form-control w-auto" name="dailyTime" id="dailyTime" value="{$DailyTime}">
+        </div>
+        <div class="mb-3">
+            <label for="taxPercent" class="form-label">{translate key="Tax"}</label>
+            <input type="number" step="0.01" class="form-control w-auto" name="taxPercent" id="taxPercent" value="{$TaxPercent}">
+        </div>
+        <div class="mb-3">
+            <label for="groups" class="form-label">{translate key="Groups"}</label>
+            <select multiple class="form-select" name="groups[]" id="groups">
+                {foreach from=$Groups item=g}
+                    <option value="{$g->Id()}" {if in_array($g->Id(), $SelectedGroups)}selected{/if}>{$g->Name()}</option>
+                {/foreach}
+            </select>
+        </div>
+        <input type="hidden" name="{QueryStringKeys::ACTION}" value="save" />
+        <button type="submit" class="btn btn-primary">{translate key="Save"}</button>
+    </form>
+</div>
+
+{include file='globalfooter.tpl'}

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -246,6 +246,7 @@
                                                     href="{$Path}admin/manage_payments.php">{translate key="ManagePayments"}</a>
                                             </li>
                                         {/if}
+                                            <li id="navManageCreditAutomation"><a class="dropdown-item" href="{$Path}admin/manage_credit_automation.php">{translate key="ManageCreditAutomation"}</a></li>
                                         <li id="navManageAttributes"><a class="dropdown-item"
                                                 href="{$Path}admin/manage_attributes.php">{translate key="CustomAttributes"}</a>
                                         </li>


### PR DESCRIPTION
## Summary
- introduce config keys for credit automation
- add daily credit job
- create admin page to manage credit automation
- add translations and navigation link
- include basic unit test for presenter

## Testing
- `vendor/bin/phpunit tests/Presenters/Admin/ManageCreditAutomationPresenterTest.php`
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: Missing config file)*

------
https://chatgpt.com/codex/tasks/task_e_685e9e4e742c8327b9fffb81e1b67eb7