### PR TITLE
Implement scheduled credit automation

### DIFF
--- a/Jobs/scheduledcredits.php
+++ b/Jobs/scheduledcredits.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Cron job to award scheduled credits to all users
+ */
+
+define('ROOT_DIR', __DIR__ . '/../');
+require_once(ROOT_DIR . 'Domain/Access/UserRepository.php');
+require_once(ROOT_DIR . 'lib/Database/Commands/namespace.php');
+require_once(ROOT_DIR . 'Jobs/JobCop.php');
+require_once(ROOT_DIR . 'lib/Config/Configuration.php');
+require_once(ROOT_DIR . 'lib/Config/Configurator.php');
+require_once(ROOT_DIR . 'lib/Common/Date.php');
+
+Log::Debug('Running scheduledcredits.php');
+JobCop::EnsureCommandLine();
+
+try {
+    $amount = floatval(Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_SCHEDULE_AMOUNT));
+    $period = intval(Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_SCHEDULE_PERIOD));
+    $max = floatval(Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_MAX_BALANCE));
+    $last = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_LAST_RUN);
+
+    if ($amount <= 0 || $period <= 0) {
+        return;
+    }
+
+    $shouldRun = true;
+    if (!empty($last)) {
+        $lastDate = Date::FromDatabase($last);
+        $diff = DateDiff::BetweenDates($lastDate, Date::Now())->Days();
+        if ($diff < $period) {
+            $shouldRun = false;
+        }
+    }
+
+    if ($shouldRun) {
+        $repo = new UserRepository();
+        $db = ServiceLocator::GetDatabase();
+        $users = $repo->GetAll();
+        foreach ($users as $user) {
+            $current = floatval($user->CurrentCreditCount());
+            $grant = $amount;
+            if ($max > 0 && ($current + $amount) > $max) {
+                $grant = max(0, $max - $current);
+            }
+            if ($grant > 0) {
+                $db->Execute(new AdjustUserCreditsCommand($user->UserId, -$grant, Resources::GetInstance()->GetString('NoteDailyCreditsAwarded')));
+            }
+        }
+
+        $conf = new Configurator();
+        $settings = $conf->GetSettings(ROOT_DIR . 'config/config.php');
+        $settings['credits'][ConfigKeys::CREDITS_LAST_RUN] = Date::Now()->ToDatabase();
+        $conf->WriteSettings(ROOT_DIR . 'config/config.php', $settings);
+    }
+} catch (Exception $ex) {
+    Log::Error('Error running scheduledcredits.php: %s', $ex);
+}
+
+Log::Debug('Finished running scheduledcredits.php');
+

--- a/Pages/Admin/ManageCreditAutomationPage.php
+++ b/Pages/Admin/ManageCreditAutomationPage.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once(ROOT_DIR . 'Pages/Admin/AdminPage.php');
+require_once(ROOT_DIR . 'Presenters/Admin/ManageCreditAutomationPresenter.php');
+
+interface IManageCreditAutomationPage extends IActionPage
+{
+    public function GetScheduleAmount();
+    public function GetSchedulePeriod();
+    public function GetScheduleTime();
+    public function GetMaxCredit();
+    public function GetImmediateAmount();
+    public function BindSettings($amount, $period, $time, $max);
+}
+
+class ManageCreditAutomationPage extends ActionPage implements IManageCreditAutomationPage
+{
+    private $presenter;
+
+    public function __construct()
+    {
+        parent::__construct('ManageCreditAutomation', 1);
+        $this->presenter = new ManageCreditAutomationPresenter($this, new Configurator());
+    }
+
+    public function ProcessPageLoad()
+    {
+        $this->presenter->PageLoad();
+        $this->Display('Admin/manage_credit_automation.tpl');
+    }
+
+    public function ProcessDataRequest($dataRequest){}
+
+    public function ProcessAction()
+    {
+        $this->presenter->ProcessAction();
+    }
+
+    public function GetScheduleAmount()
+    {
+        return $this->GetForm('scheduleAmount');
+    }
+
+    public function GetSchedulePeriod()
+    {
+        return $this->GetForm('schedulePeriod');
+    }
+
+    public function GetScheduleTime()
+    {
+        return $this->GetForm('scheduleTime');
+    }
+
+    public function GetMaxCredit()
+    {
+        return $this->GetForm('maxCredit');
+    }
+
+    public function GetImmediateAmount()
+    {
+        return $this->GetForm('immediateAmount');
+    }
+
+    public function BindSettings($amount, $period, $time, $max)
+    {
+        $this->Set('ScheduleAmount', $amount);
+        $this->Set('SchedulePeriod', $period);
+        $this->Set('ScheduleTime', $time);
+        $this->Set('MaxCredit', $max);
+    }
+}

--- a/Presenters/Admin/ManageCreditAutomationPresenter.php
+++ b/Presenters/Admin/ManageCreditAutomationPresenter.php
@@ -1,0 +1,74 @@
+<?php
+require_once(ROOT_DIR . 'Presenters/ActionPresenter.php');
+require_once(ROOT_DIR . 'lib/Config/Configurator.php');
+require_once(ROOT_DIR . 'Domain/Access/UserRepository.php');
+require_once(ROOT_DIR . 'lib/Database/Commands/namespace.php');
+
+class ManageCreditAutomationActions
+{
+    public const SAVE = 'save';
+    public const UPDATE_NOW = 'updateNow';
+}
+
+class ManageCreditAutomationPresenter extends ActionPresenter
+{
+    private $page;
+    private $config;
+    private $configFile;
+
+    public function __construct(IManageCreditAutomationPage $page, IConfigurationSettings $config)
+    {
+        parent::__construct($page);
+        $this->page = $page;
+        $this->config = $config;
+        $this->configFile = ROOT_DIR . 'config/config.php';
+        $this->AddAction(ManageCreditAutomationActions::SAVE, 'Save');
+        $this->AddAction(ManageCreditAutomationActions::UPDATE_NOW, 'UpdateNow');
+    }
+
+    public function PageLoad()
+    {
+        $amount = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_SCHEDULE_AMOUNT);
+        $period = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_SCHEDULE_PERIOD);
+        $time = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_SCHEDULE_TIME);
+        $max = Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_MAX_BALANCE);
+        $this->page->BindSettings($amount, $period, $time, $max);
+    }
+
+    public function Save()
+    {
+        $settings = $this->config->GetSettings($this->configFile);
+        $settings['credits'][ConfigKeys::CREDITS_SCHEDULE_AMOUNT] = $this->page->GetScheduleAmount();
+        $settings['credits'][ConfigKeys::CREDITS_SCHEDULE_PERIOD] = $this->page->GetSchedulePeriod();
+        $settings['credits'][ConfigKeys::CREDITS_SCHEDULE_TIME] = $this->page->GetScheduleTime();
+        $settings['credits'][ConfigKeys::CREDITS_MAX_BALANCE] = $this->page->GetMaxCredit();
+        $this->config->WriteSettings($this->configFile, $settings);
+    }
+
+    public function UpdateNow()
+    {
+        $amount = floatval($this->page->GetImmediateAmount());
+        $max = floatval(Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_MAX_BALANCE));
+        if ($amount <= 0) {
+            return;
+        }
+        $this->AwardCredits($amount, $max);
+    }
+
+    private function AwardCredits($amount, $max)
+    {
+        $repo = new UserRepository();
+        $db = ServiceLocator::GetDatabase();
+        $users = $repo->GetAll();
+        foreach ($users as $user) {
+            $current = floatval($user->CurrentCreditCount());
+            $grant = $amount;
+            if ($max > 0 && ($current + $amount) > $max) {
+                $grant = max(0, $max - $current);
+            }
+            if ($grant > 0) {
+                $db->Execute(new AdjustUserCreditsCommand($user->UserId, -$grant, Resources::GetInstance()->GetString('CreditsUpdatedLog', [ServiceLocator::GetServer()->GetUserSession()] )));
+            }
+        }
+    }
+}

--- a/Web/admin/manage_credit_automation.php
+++ b/Web/admin/manage_credit_automation.php
@@ -1,0 +1,10 @@
+<?php
+
+if (!defined('ROOT_DIR')) {
+    define('ROOT_DIR', dirname(__DIR__, 2) . '/');
+}
+
+require_once(ROOT_DIR . 'Pages/Admin/ManageCreditAutomationPage.php');
+
+$page = new AdminPageDecorator(new ManageCreditAutomationPage());
+$page->PageLoad();

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -195,6 +195,15 @@ $conf['settings']['authentication']['captcha.on.login'] = 'false';
  */
 $conf['settings']['credits']['enabled'] = 'false';
 $conf['settings']['credits']['allow.purchase'] = 'false';
+$conf['settings']['credits']['daily.amount'] = '0';
+$conf['settings']['credits']['daily.groups'] = '';
+$conf['settings']['credits']['daily.time'] = '00:00';
+$conf['settings']['credits']['tax.percent'] = '0';
+$conf['settings']['credits']['schedule.amount'] = '0';
+$conf['settings']['credits']['schedule.period'] = '1';
+$conf['settings']['credits']['schedule.time'] = '00:00';
+$conf['settings']['credits']['max.balance'] = '0';
+$conf['settings']['credits']['schedule.last'] = '';
 /**
  * Slack integration
  */

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -199,6 +199,15 @@ $conf['settings']['authentication']['captcha.on.login'] = 'false';
  */
 $conf['settings']['credits']['enabled'] = 'false';
 $conf['settings']['credits']['allow.purchase'] = 'false';
+$conf['settings']['credits']['daily.amount'] = '0';
+$conf['settings']['credits']['daily.groups'] = '';
+$conf['settings']['credits']['daily.time'] = '00:00';
+$conf['settings']['credits']['tax.percent'] = '0';
+$conf['settings']['credits']['schedule.amount'] = '0';
+$conf['settings']['credits']['schedule.period'] = '1';
+$conf['settings']['credits']['schedule.time'] = '00:00';
+$conf['settings']['credits']['max.balance'] = '0';
+$conf['settings']['credits']['schedule.last'] = '';
 /**
  * Slack integration
  */

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -63,6 +63,11 @@ class ar extends en_us
         $strings['Update'] = 'تحديث';
         $strings['Cancel'] = 'إالغاء';
         $strings['Add'] = 'إضافة';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'الاسم';
         $strings['Yes'] = 'نعم';
         $strings['No'] = 'لا';
@@ -654,6 +659,8 @@ class ar extends en_us
         $strings['TryAgain'] = 'محاولة مرة اخرى ';
         $strings['PurchaseFailed'] = 'لقد واجهتنا مشكلة في معالجة دفعتك.';
         $strings['NoteCreditsPurchased'] = 'شراء الاعتمادات';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'تم تحديث الاعتمادات بواسطة %s';
         $strings['ReservationCreatedLog'] = 'تم إنشاء الحجز. رقم المرجع %s';
         $strings['ReservationUpdatedLog'] = 'تم تحديث الحجز. رقم المرجع %s';
@@ -935,6 +942,7 @@ class ar extends en_us
         $strings['ReservationColors'] = 'الوان الحجوزات ';
         $strings['SearchReservations'] = 'بحث عن الحجوزات';
         $strings['ManagePayments'] = 'المدفوعات';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'عرض التقويم';
         $strings['DataCleanup'] = 'تنظيف البيانات';
         $strings['ManageEmailTemplates'] = 'إدارة قوالب البريد الإلكتروني';

--- a/lang/da_da.php
+++ b/lang/da_da.php
@@ -58,6 +58,11 @@ class da_da extends en_gb
         $strings['Update'] = 'Opdatér';
         $strings['Cancel'] = 'Annuller';
         $strings['Add'] = 'Tilføj';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Navn';
         $strings['Yes'] = 'Ja';
         $strings['No'] = 'Nej';
@@ -649,6 +654,8 @@ class da_da extends en_gb
         $strings['TryAgain'] = 'Prøv igen';
         $strings['PurchaseFailed'] = 'Der var problemer med din betaling';
         $strings['NoteCreditsPurchased'] = 'Mønter anskaffet';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Mønter er opdateret med %s';
         $strings['ReservationCreatedLog'] = 'Din reservation er oprettet. Referencenummer %s';
         $strings['ReservationUpdatedLog'] = 'Din reservation er opdateret. Referencenummer %s';
@@ -930,6 +937,7 @@ class da_da extends en_gb
         $strings['ReservationColors'] = 'Reservationsfarver';
         $strings['SearchReservations'] = 'Find reservation';
         $strings['ManagePayments'] = 'Betalling';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Se kalender';
         $strings['DataCleanup'] = 'Fjern data';
         $strings['ManageEmailTemplates'] = 'E-mailskabeloner';

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -23,6 +23,11 @@ class de_de extends en_gb
         $strings['Update'] = 'Update';
         $strings['Cancel'] = 'Abbrechen';
         $strings['Add'] = 'Hinzufügen';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Name';
         $strings['Yes'] = 'Ja';
         $strings['No'] = 'Nein';
@@ -615,6 +620,8 @@ class de_de extends en_gb
         $strings['TryAgain'] = 'Noch einmal versuchen';
         $strings['PurchaseFailed'] = 'Wir konnten ihre Bezahlung nicht vollständig abwickeln.';
         $strings['NoteCreditsPurchased'] = 'Punkte gekauft';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Punkte aktualisiert durch %s';
         $strings['ReservationCreatedLog'] = 'Reservierung angelegt. Referenznummer %s';
         $strings['ReservationUpdatedLog'] = 'Reservierung aktualisiert. Referenznummer %s';
@@ -909,6 +916,7 @@ class de_de extends en_gb
         $strings['ReservationColors'] = 'Reservierungsfarben';
         $strings['SearchReservations'] = 'Reservierungen finden';
         $strings['ManagePayments'] = 'Zahlungen';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Kalender anschauen';
         $strings['DataCleanup'] = 'Daten aufräumen';
         $strings['ManageEmailTemplates'] = 'E-Mail Vorlagen bearbeiten';

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -25,6 +25,11 @@ class du_nl extends en_gb
         $strings['Update'] = 'Pas aan';
         $strings['Cancel'] = 'Annuleer';
         $strings['Add'] = 'Voeg toe';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Naam';
         $strings['Yes'] = 'Ja';
         $strings['No'] = 'Nee';
@@ -624,6 +629,8 @@ class du_nl extends en_gb
         $strings['TryAgain'] = 'Probeer opnieuw';
         $strings['PurchaseFailed'] = 'We had trouble processing your payment.';
         $strings['NoteCreditsPurchased'] = 'Credits purchased';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Credits updated by %s';
         $strings['ReservationCreatedLog'] = 'Reservation created. Reference number %s';
         $strings['ReservationUpdatedLog'] = 'Reservation updated. Reference number %s';
@@ -922,6 +929,7 @@ class du_nl extends en_gb
         $strings['ReservationColors'] = 'Reserverings kleur';
 		$strings['SearchReservations'] = 'Zoek reservering';
 		$strings['ManagePayments'] = 'Betalingen';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
 		$strings['ViewCalendar'] = 'Bekijk kalender';
 		$strings['DataCleanup'] = 'Data opschonen';
 		$strings['ManageEmailTemplates'] = 'E-mail sjablonen beheren';

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -63,6 +63,11 @@ class el_gr extends en_gb
         $strings['Update'] = 'Ενημέρωση';
         $strings['Cancel'] = 'Άκυρο';
         $strings['Add'] = 'Προσθήκη';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Όνομα';
         $strings['Yes'] = 'Ναι';
         $strings['No'] = 'Όχι';
@@ -654,6 +659,8 @@ class el_gr extends en_gb
         $strings['TryAgain'] = 'Δοκιμάστε πάλι';
         $strings['PurchaseFailed'] = 'Πρόβλημα κατά την επεξεργασία της πληρωμής σας.';
         $strings['NoteCreditsPurchased'] = 'Τα credits αγοράστηκαν';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Τα credits τροποποιήθηκαν από %s';
         $strings['ReservationCreatedLog'] = 'Η κράτηση δημιουργήθηκε. Αριθμός αναφοράς %s';
         $strings['ReservationUpdatedLog'] = 'Η κράτηση τροποποιήθηκε. Αριθμός αναφοράς %s';
@@ -947,6 +954,7 @@ class el_gr extends en_gb
         $strings['ReservationColors'] = 'Χρώματα Κρατήσεων';
         $strings['SearchReservations'] = 'Αναζήτηση στις Κρατήσεις';
         $strings['ManagePayments'] = 'Πληρωμές';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Εμφάνιση Ημερολογίου';
         $strings['DataCleanup'] = 'Εκκαθάριση Δεδομένων';
         $strings['ManageEmailTemplates'] = 'Διαχείριση Προτύπων Email';

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -62,6 +62,11 @@ class en_us extends Language
         $strings['Update'] = 'Update';
         $strings['Cancel'] = 'Cancel';
         $strings['Add'] = 'Add';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Name';
         $strings['Yes'] = 'Yes';
         $strings['No'] = 'No';
@@ -657,6 +662,8 @@ class en_us extends Language
         $strings['TryAgain'] = 'Try Again';
         $strings['PurchaseFailed'] = 'We had trouble processing your payment.';
         $strings['NoteCreditsPurchased'] = 'Credits purchased';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Credits updated by %s';
         $strings['ReservationCreatedLog'] = 'Reservation created. Reference number %s';
         $strings['ReservationUpdatedLog'] = 'Reservation updated. Reference number %s';
@@ -952,6 +959,7 @@ class en_us extends Language
         $strings['ReservationColors'] = 'Reservation Colors';
         $strings['SearchReservations'] = 'Search Reservations';
         $strings['ManagePayments'] = 'Payments';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'View Calendar';
         $strings['DataCleanup'] = 'Data Cleanup';
         $strings['ManageEmailTemplates'] = 'Manage Email Templates';

--- a/lang/es.php
+++ b/lang/es.php
@@ -25,6 +25,11 @@ class es extends en_gb
         $strings['Update'] = 'Actualizar';
         $strings['Cancel'] = 'Cancelar';
         $strings['Add'] = 'Agregar';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Nombre';
         $strings['Yes'] = 'Sí';
         $strings['No'] = 'No';
@@ -620,6 +625,8 @@ class es extends en_gb
         $strings['TryAgain'] = 'Intentar de nuevo';
         $strings['PurchaseFailed'] = 'Hemos tenido problemas procesando su pago.';
         $strings['NoteCreditsPurchased'] = 'Créditos comprados';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Créditos actualizados por %s';
         $strings['ReservationCreatedLog'] = 'Reserva creada. Número de referencia %s';
         $strings['ReservationUpdatedLog'] = 'Reserva actualizada. Número de referencia %s';
@@ -915,6 +922,7 @@ class es extends en_gb
         $strings['ReservationColors'] = 'Colores de las reservas';
         $strings['SearchReservations'] = 'Buscar Reservas';
         $strings['ManagePayments'] = 'Pagos';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Ver Calendario';
         $strings['DataCleanup'] = 'Limpiar Datos';
         $strings['ManageEmailTemplates'] = 'Administrar Plantillas de Correo Electrónico';

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -23,6 +23,11 @@ class fi_fi extends en_gb
         $strings['Update'] = 'Päivitä';
         $strings['Cancel'] = 'Peruuta';
         $strings['Add'] = 'Lisää';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Nimi';
         $strings['Yes'] = 'Kyllä';
         $strings['No'] = 'Ei';
@@ -627,6 +632,8 @@ class fi_fi extends en_gb
         $strings['TryAgain'] = 'Yritä Uudelleen';
         $strings['PurchaseFailed'] = 'Maksusi kanssa oli ongelmia.';
         $strings['NoteCreditsPurchased'] = 'Krediittiä ostettu';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = '%s on päivittänyt Krediitit';
         $strings['ReservationCreatedLog'] = 'Varaus luotu. Varausnumero %s';
         $strings['ReservationUpdatedLog'] = 'Varaus päivitetty. Varausnumero %s';
@@ -846,6 +853,7 @@ class fi_fi extends en_gb
         $strings['ReservationColors'] = 'Varausten Värit';
         $strings['SearchReservations'] = 'Etsi Varauksia';
         $strings['ManagePayments'] = 'Maksut';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Katso Kalenteria';
         $strings['DataCleanup'] = 'Datan Poista';
         $strings['ManageEmailTemplates'] = 'Hallitse Sähköpostipohjia';

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -25,6 +25,11 @@ class fr_fr extends en_gb
         $strings['Update'] = 'Enregistrer';
         $strings['Cancel'] = 'Annuler';
         $strings['Add'] = 'Ajouter';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Nom';
         $strings['Yes'] = 'Oui';
         $strings['No'] = 'Non';
@@ -619,6 +624,8 @@ class fr_fr extends en_gb
         $strings['TryAgain'] = 'Essayer à nouveau';
         $strings['PurchaseFailed'] = 'Nous avons eu un probème lors du traitement de votre paiement.';
         $strings['NoteCreditsPurchased'] = 'Crédits achetés';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Crédits achetés par %s';
         $strings['ReservationCreatedLog'] = 'Réservation créée. Numéro de reference %s';
         $strings['ReservationUpdatedLog'] = 'Réservation modifiée. Numéro de reference %s';
@@ -912,6 +919,7 @@ class fr_fr extends en_gb
         $strings['ReservationColors'] = 'Couleurs des Réservations';
         $strings['SearchReservations'] = 'Rechercher des Réservations';
         $strings['ManagePayments'] = 'Paiements';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Voir le Calendrier';
         $strings['DataCleanup'] = 'Nettoyage des données';
         $strings['ManageEmailTemplates'] = 'Gérer les Modèles de Email';

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -57,6 +57,11 @@ class hu_hu extends en_us
         $strings['Update'] = 'Frisstés';
         $strings['Cancel'] = 'Mégse';
         $strings['Add'] = 'Hozzáad';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Név';
         $strings['Yes'] = 'Igen';
         $strings['No'] = 'Nem';
@@ -648,6 +653,8 @@ class hu_hu extends en_us
         $strings['TryAgain'] = 'Újra próbál';
         $strings['PurchaseFailed'] = 'Probléma a fizetés közben.';
         $strings['NoteCreditsPurchased'] = 'Egység megvásárolva';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Egység frissítve %s által';
         $strings['ReservationCreatedLog'] = 'Foglalás létrehozva. Referenciaszám %s';
         $strings['ReservationUpdatedLog'] = 'Foglalás frissítve. Referenciaszám %s';
@@ -908,6 +915,7 @@ class hu_hu extends en_us
         $strings['ReservationColors'] = 'Foglalások színei';
         $strings['SearchReservations'] = 'Foglalás keresése';
         $strings['ManagePayments'] = 'Kifizetések';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Naptár megtekintése';
         $strings['DataCleanup'] = 'Adat törlés';
         $strings['ManageEmailTemplates'] = 'E-mail sablonok kezelése';

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -61,6 +61,11 @@ class it_it extends en_us
         $strings['Update'] = 'Aggiorna';
         $strings['Cancel'] = 'Annulla';
         $strings['Add'] = 'Aggiungi';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Nome';
         $strings['Yes'] = 'S&igrave;';
         $strings['No'] = 'No';
@@ -652,6 +657,8 @@ class it_it extends en_us
         $strings['TryAgain'] = 'Riprova';
         $strings['PurchaseFailed'] = 'Abbiamo riscontrato problemi durante l&apos;elaborazione del pagamento.';
         $strings['NoteCreditsPurchased'] = 'Crediti acquistati';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Crediti aggiornati da %s';
         $strings['ReservationCreatedLog'] = 'Prenotazione creata. Numero Riferimento %s';
         $strings['ReservationUpdatedLog'] = 'Prenotazione aggiornata. Numero Riferimento %s';
@@ -948,6 +955,7 @@ class it_it extends en_us
         $strings['ReservationColors'] = 'Colori delle prenotazioni';
         $strings['SearchReservations'] = 'Cerca Prenotazioni';
         $strings['ManagePayments'] = 'Pagamenti';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Visualizza calendario';
         $strings['DataCleanup'] = 'Pulizia dei dati';
         $strings['ManageEmailTemplates'] = 'Gestisci template email';

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -63,6 +63,11 @@ class ja_jp extends en_gb
         $strings['Update'] = '更新';
         $strings['Cancel'] = 'キャンセル';
         $strings['Add'] = '追加';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = '名前';
         $strings['Yes'] = 'はい';
         $strings['No'] = 'いいえ';
@@ -660,6 +665,8 @@ class ja_jp extends en_gb
         $strings['TryAgain'] = '再試行';
         $strings['PurchaseFailed'] = '支払いの処理中に問題が発生しました';
         $strings['NoteCreditsPurchased'] = '購入したクレジット';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = '%s が更新したクレジット';
         $strings['ReservationCreatedLog'] = '予約が作成されました。参照番号 %s ';
         $strings['ReservationUpdatedLog'] = '予約が変更されました。参照番号 %s ';
@@ -927,6 +934,7 @@ class ja_jp extends en_gb
         $strings['SearchReservations'] = '予約の検索';
 
         $strings['ManagePayments'] = '支払';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'カレンダーを表示';
         $strings['DataCleanup'] = 'データクリーンアップ';
         $strings['ManageEmailTemplates'] = 'メールテンプレートの管理';

--- a/lang/lt.php
+++ b/lang/lt.php
@@ -28,6 +28,11 @@ class lt extends en_gb
         $strings['Update'] = 'Atnaujinti';
         $strings['Cancel'] = 'Atšaukti';
         $strings['Add'] = 'Pridėti';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Pavadinimas';
         $strings['Yes'] = 'Taip';
         $strings['No'] = 'Ne';
@@ -619,6 +624,8 @@ class lt extends en_gb
         $strings['TryAgain'] = 'Try Again';
         $strings['PurchaseFailed'] = 'We had trouble processing your payment.';
         $strings['NoteCreditsPurchased'] = 'Credits purchased';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Credits updated by %s';
         $strings['ReservationCreatedLog'] = 'Reservation created. Reference number %s';
         $strings['ReservationUpdatedLog'] = 'Reservation updated. Reference number %s';
@@ -912,6 +919,7 @@ class lt extends en_gb
         $strings['ReservationColors'] = 'Rezervacijų spalvos';
         $strings['SearchReservations'] = 'Ieškoti rezervacijų';
         $strings['ManagePayments'] = 'Payments';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'View Calendar';
         $strings['DataCleanup'] = 'Data Cleanup';
         $strings['ManageEmailTemplates'] = 'Manage Email Templates';

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -67,6 +67,11 @@ class pl extends en_gb
         $strings['Update'] = 'Aktualizuj';
         $strings['Cancel'] = 'Anuluj';
         $strings['Add'] = 'Dodaj';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Nazwa';
         $strings['Yes'] = 'Tak';
         $strings['No'] = 'Nie';
@@ -658,6 +663,8 @@ class pl extends en_gb
         $strings['TryAgain'] = 'Spróbuj ponownie';
         $strings['PurchaseFailed'] = 'Wystąpił problem z przetwarzaniem Twojej płatności.';
         $strings['NoteCreditsPurchased'] = 'Zakupione żetony';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Żetony zaktualizowane przez %s';
         $strings['ReservationCreatedLog'] = 'Rezerwacja utworzona: Nr referencyjny: %s';
         $strings['ReservationUpdatedLog'] = 'Rezerwacja zmieniona: Nr referencyjny:%s';
@@ -953,6 +960,7 @@ class pl extends en_gb
         $strings['ReservationColors'] = 'Kolory rezerwacji';
         $strings['SearchReservations'] = 'Przeszukaj rezerwacje';
         $strings['ManagePayments'] = 'Płatności';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Podgląd kalendarza';
         $strings['DataCleanup'] = 'Czyszczenie danych';
         $strings['ManageEmailTemplates'] = 'Zarządzaj szablonami e-maili';

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -28,6 +28,11 @@ class pt_br extends en_gb
         $strings['Update'] = 'Atualizar';
         $strings['Cancel'] = 'Cancelar';
         $strings['Add'] = 'Adicionar';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['Name'] = 'Nome';
         $strings['Yes'] = 'Sim';
         $strings['No'] = 'Não';
@@ -637,6 +642,8 @@ class pt_br extends en_gb
         $strings['TryAgain'] = 'Tente novamente';
         $strings['PurchaseFailed'] = 'Ocorreu um problema ao processar seu pagamento.';
         $strings['NoteCreditsPurchased'] = 'Créditos adquiridos';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['CreditsUpdatedLog'] = 'Créditos atualizados por %s';
         $strings['ReservationCreatedLog'] = 'Reserva criada. Número de referência %s';
         $strings['ReservationUpdatedLog'] = 'Reserva atualizada. Número de referência %s';
@@ -936,6 +943,7 @@ class pt_br extends en_gb
         $strings['ReservationColors'] = 'Cores das reservas';
         $strings['SearchReservations'] = 'Pesquisar reservas';
         $strings['ManagePayments'] = 'Pagamentos';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ViewCalendar'] = 'Exibir calendário';
         $strings['DataCleanup'] = 'Limpeza de dados';
         $strings['ManageEmailTemplates'] = 'Gerenciar Modelos de E-mail';

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -68,6 +68,11 @@ class pt_pt extends en_gb
         $strings['Active'] = 'Ativo';
         $strings['AdHocMeeting'] = 'Reunião ad hoc';
         $strings['Add'] = 'Adicionar';
+        $strings['Save'] = 'Save';
+        $strings['Time'] = 'Time';
+        $strings['Tax'] = 'Tax';
+        $strings['Scheduled'] = 'Scheduled';
+        $strings['PeriodDays'] = 'Period (days)';
         $strings['AddAccessories'] = 'Adicionar acessórios';
         $strings['AddAccessory'] = 'Adicionar acessório';
         $strings['AddAnnouncement'] = 'Adicionar anúncio';
@@ -459,6 +464,7 @@ class pt_pt extends en_gb
         $strings['ManageEmailTemplates'] = 'Gerir modelos de email';
         $strings['ManageGroups'] = 'Grupos';
         $strings['ManagePayments'] = 'Pagamentos';
+        $strings['ManageCreditAutomation'] = 'Credit Automation';
         $strings['ManageQuotas'] = 'Quotas';
         $strings['ManageReminders'] = 'Lembretes';
         $strings['ManageReservations'] = 'Reservas';
@@ -538,6 +544,8 @@ class pt_pt extends en_gb
         $strings['NotSignedIn'] = 'Não está logado';
         $strings['Note'] = 'Nota';
         $strings['NoteCreditsPurchased'] = 'Créditos adquiridos';
+        $strings['NoteDailyCreditsAwarded'] = 'Daily credits awarded';
+        $strings['NoteCreditTaxed'] = 'Credit tax applied';
         $strings['Notes'] = 'Notas';
         $strings['NotificationPreferences'] = 'Preferências de Notificação';
         $strings['NotifyUser'] = 'Notificar utilizador';

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -9,6 +9,15 @@ class ConfigKeys
     public const ALLOW_REGISTRATION = 'allow.self.registration';
     public const CREDITS_ENABLED = 'enabled';
     public const CREDITS_ALLOW_PURCHASE = 'allow.purchase';
+    public const CREDITS_DAILY_AMOUNT = 'daily.amount';
+    public const CREDITS_DAILY_GROUPS = 'daily.groups';
+    public const CREDITS_DAILY_TIME = 'daily.time';
+    public const CREDITS_TAX_PERCENT = 'tax.percent';
+    public const CREDITS_SCHEDULE_AMOUNT = 'schedule.amount';
+    public const CREDITS_SCHEDULE_PERIOD = 'schedule.period';
+    public const CREDITS_SCHEDULE_TIME = 'schedule.time';
+    public const CREDITS_MAX_BALANCE = 'max.balance';
+    public const CREDITS_LAST_RUN = 'schedule.last';
     public const CSS_EXTENSION_FILE = 'css.extension.file';
     public const CSS_THEME = 'css.theme';
     public const DEFAULT_HOMEPAGE = 'default.homepage';

--- a/tests/Presenters/Admin/ManageCreditAutomationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageCreditAutomationPresenterTest.php
@@ -1,0 +1,55 @@
+<?php
+require_once(ROOT_DIR . 'Presenters/Admin/ManageCreditAutomationPresenter.php');
+require_once(ROOT_DIR . 'Pages/Admin/ManageCreditAutomationPage.php');
+
+class ManageCreditAutomationPresenterTest extends TestBase
+{
+    private $page;
+    private $presenter;
+    private $config;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->page = new FakeCreditAutomationPage();
+        $this->config = new FakeConfigurator();
+        $this->presenter = new ManageCreditAutomationPresenter($this->page, $this->config);
+    }
+
+
+    public function testSaveWritesSettings()
+    {
+        $this->page->_form = [
+            'scheduleAmount'=>'3',
+            'schedulePeriod'=>'2',
+            'scheduleTime'=>'01:00',
+            'maxCredit'=>'9'
+        ];
+        $this->presenter->Save();
+        $this->assertEquals('3', $this->config->_settings['credits'][ConfigKeys::CREDITS_SCHEDULE_AMOUNT]);
+    }
+}
+
+class FakeCreditAutomationPage extends ManageCreditAutomationPage
+{
+    public $_form = [];
+    public $_Amount;
+    public $_Period;
+    public $_Time;
+    public $_Max;
+
+    public function __construct(){}
+
+    public function GetForm($key){return $this->_form[$key] ?? null;}
+
+    public function BindSettings($a,$p,$t,$m){$this->_Amount=$a;$this->_Period=$p;$this->_Time=$t;$this->_Max=$m;}
+}
+
+class FakeConfigurator implements IConfigurationSettings
+{
+    public $_settings = [];
+    public function GetSettings($file){return $this->_settings;}
+    public function BuildConfig($c,$n,$r=false){}
+    public function WriteSettings($path,$set){$this->_settings=$set;}
+    public function CanOverwriteFile($f){return true;}
+}

--- a/tpl/Admin/manage_credit_automation.tpl
+++ b/tpl/Admin/manage_credit_automation.tpl
@@ -1,0 +1,36 @@
+{include file='globalheader.tpl'}
+
+<div id="page-manage-credit-automation" class="admin-page">
+    <h1 class="border-bottom mb-3">{translate key=ManageCreditAutomation}</h1>
+    <form id="credit-automation-form" method="post" action="manage_credit_automation.php">
+        <div class="mb-3 d-flex align-items-end">
+            <div>
+                <label for="immediateAmount" class="form-label">{translate key="Credits"}</label>
+                <input type="number" step="0.01" class="form-control w-auto" name="immediateAmount" id="immediateAmount">
+            </div>
+            <button type="submit" name="{QueryStringKeys::ACTION}" value="updateNow" class="btn btn-secondary ms-2">{translate key="Update"}</button>
+        </div>
+        <fieldset class="border p-3">
+            <legend class="float-none w-auto px-2">{translate key="Scheduled"}</legend>
+            <div class="mb-3">
+                <label for="scheduleAmount" class="form-label">{translate key="Credits"}</label>
+                <input type="number" step="0.01" class="form-control w-auto" name="scheduleAmount" id="scheduleAmount" value="{$ScheduleAmount}">
+            </div>
+            <div class="mb-3">
+                <label for="schedulePeriod" class="form-label">{translate key="PeriodDays"}</label>
+                <input type="number" class="form-control w-auto" name="schedulePeriod" id="schedulePeriod" value="{$SchedulePeriod}">
+            </div>
+            <div class="mb-3">
+                <label for="scheduleTime" class="form-label">{translate key="Time"}</label>
+                <input type="time" class="form-control w-auto" name="scheduleTime" id="scheduleTime" value="{$ScheduleTime}">
+            </div>
+            <div class="mb-3">
+                <label for="maxCredit" class="form-label">{translate key="Maximum"}</label>
+                <input type="number" step="0.01" class="form-control w-auto" name="maxCredit" id="maxCredit" value="{$MaxCredit}">
+            </div>
+            <button type="submit" name="{QueryStringKeys::ACTION}" value="save" class="btn btn-primary">{translate key="Save"}</button>
+        </fieldset>
+    </form>
+</div>
+
+{include file='globalfooter.tpl'}

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -246,6 +246,7 @@
                                                     href="{$Path}admin/manage_payments.php">{translate key="ManagePayments"}</a>
                                             </li>
                                         {/if}
+                                            <li id="navManageCreditAutomation"><a class="dropdown-item" href="{$Path}admin/manage_credit_automation.php">{translate key="ManageCreditAutomation"}</a></li>
                                         <li id="navManageAttributes"><a class="dropdown-item"
                                                 href="{$Path}admin/manage_attributes.php">{translate key="CustomAttributes"}</a>
                                         </li>


### PR DESCRIPTION
## Summary
- replace daily credit job with scheduled credit automation job
- allow admins to set schedule amount, period and max balance
- support immediate credit updates via admin page
- add new config keys and translations
- update test for presenter

## Testing
- `./vendor/bin/phpunit tests/Presenters/Admin/ManageCreditAutomationPresenterTest.php`


------
https://chatgpt.com/codex/tasks/task_e_685e9e4e742c8327b9fffb81e1b67eb7